### PR TITLE
installation: fix invenio_upgrader dependency

### DIFF
--- a/invenio_collections/collections_2015_07_14_innodb.py
+++ b/invenio_collections/collections_2015_07_14_innodb.py
@@ -20,7 +20,8 @@
 """Fixes foreign key relationship."""
 
 from invenio.ext.sqlalchemy import db
-from invenio.modules.upgrader.api import op
+
+from invenio_upgrader.api import op
 
 depends_on = ['invenio_2015_03_03_tag_value']
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -23,5 +23,6 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 -e git+git://github.com/inveniosoftware/dojson.git#egg=dojson
+-e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader
 -e git+git://github.com/inveniosoftware/invenio-formatter.git#egg=invenio-formatter
 -e git+git://github.com/inveniosoftware/invenio-search.git#egg=invenio-search

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ requirements = [
     'six>=1.7.2',
     'intbitset>=2.0',
     'dojson>=0.1.1',
+    'invenio-upgrader>=0.1.0',
     'invenio-formatter>=0.2.0',
     'invenio-search>=0.1.0',
 ]
@@ -53,6 +54,7 @@ test_requirements = [
 
 
 class PyTest(TestCommand):
+
     """PyTest Test."""
 
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]


### PR DESCRIPTION
* FIX Adds missing `invenio_upgrader` dependency and amends past upgrade
  recipes following its separation into standalone package.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>