### PR TITLE
installation: fix invenio_access import

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -30,4 +30,5 @@ Invenio module for organizing metadata into collections.
 - Jiri Kuncar <jiri.kuncar@cern.ch>
 - Leonardo Rossi <leonardo.r@cern.ch>
 - Marco Neumann <marco@crepererum.net>
+- Sami Hiltunen <sami.mikael.hiltunen@cern.ch>
 - Tibor Simko <tibor.simko@cern.ch>

--- a/invenio_collections/cache.py
+++ b/invenio_collections/cache.py
@@ -74,9 +74,9 @@ def get_collection_nbrecs(coll):
 class RestrictedCollectionDataCacher(DataCacher):
     def __init__(self):
         def cache_filler():
-            from invenio.modules.access.control import acc_get_action_id
-            from invenio.modules.access.local_config import VIEWRESTRCOLL
-            from invenio.modules.access.models import (
+            from invenio_access.control import acc_get_action_id
+            from invenio_access.local_config import VIEWRESTRCOLL
+            from invenio_access.models import (
                 AccAuthorization, AccARGUMENT
             )
             VIEWRESTRCOLL_ID = acc_get_action_id(VIEWRESTRCOLL)

--- a/invenio_collections/decorators.py
+++ b/invenio_collections/decorators.py
@@ -55,8 +55,8 @@ def check_collection(method=None, name_getter=None, default_collection=False):
             return abort(404)
 
         if collection.is_restricted:
-            from invenio.modules.access.engine import acc_authorize_action
-            from invenio.modules.access.local_config import VIEWRESTRCOLL
+            from invenio_access.engine import acc_authorize_action
+            from invenio_access.local_config import VIEWRESTRCOLL
             (auth_code, auth_msg) = acc_authorize_action(
                 uid,
                 VIEWRESTRCOLL,

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -23,6 +23,7 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 -e git+git://github.com/inveniosoftware/dojson.git#egg=dojson
--e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader
+-e git+git://github.com/inveniosoftware/invenio-access.git#egg=invenio-access
 -e git+git://github.com/inveniosoftware/invenio-formatter.git#egg=invenio-formatter
 -e git+git://github.com/inveniosoftware/invenio-search.git#egg=invenio-search
+-e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ requirements = [
     'six>=1.7.2',
     'intbitset>=2.0',
     'dojson>=0.1.1',
+    'invenio-access>=0.1.0',
     'invenio-upgrader>=0.1.0',
     'invenio-formatter>=0.2.0',
     'invenio-search>=0.1.0',


### PR DESCRIPTION
* Adds missing `invenio_access` dependency and amends past upgrade
  recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>