### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/invenio_collections/cache.py
+++ b/invenio_collections/cache.py
@@ -24,7 +24,7 @@ import warnings
 from sqlalchemy import event
 from werkzeug.utils import cached_property
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.ext.cache import cache
 
 from invenio_access.control import acc_get_action_id

--- a/invenio_collections/decorators.py
+++ b/invenio_collections/decorators.py
@@ -22,7 +22,7 @@ import functools
 from flask import abort, flash, g, redirect, request, url_for
 from flask_login import current_user
 
-from invenio.base.i18n import _
+from invenio_base.i18n import _
 
 from .models import Collection
 

--- a/invenio_collections/forms.py
+++ b/invenio_collections/forms.py
@@ -21,7 +21,7 @@
 
 from wtforms import HiddenField, SelectField, StringField, TextField
 
-from invenio.base.i18n import _
+from invenio_base.i18n import _
 from invenio.utils.forms import InvenioBaseForm
 
 from .models import get_pbx_pos

--- a/invenio_collections/views/admin.py
+++ b/invenio_collections/views/admin.py
@@ -26,8 +26,8 @@ from flask import Blueprint, abort, flash, g, redirect, render_template, \
 from flask_breadcrumbs import register_breadcrumb
 from flask_login import current_user, login_required
 
-from invenio.base.decorators import templated
-from invenio.base.i18n import _, language_list_long
+from invenio_base.decorators import templated
+from invenio_base.i18n import _, language_list_long
 from invenio.ext.principal import permission_required
 from invenio.ext.sqlalchemy import db
 

--- a/invenio_collections/views/collections.py
+++ b/invenio_collections/views/collections.py
@@ -26,8 +26,8 @@ from flask_breadcrumbs import current_breadcrumbs, default_breadcrumb_root, \
     register_breadcrumb
 from flask_menu import register_menu
 
-from invenio.base.decorators import templated, wash_arguments
-from invenio.base.i18n import _
+from invenio_base.decorators import templated, wash_arguments
+from invenio_base.i18n import _
 from invenio.ext.template.context_processor import \
     register_template_context_processor
 from invenio.utils.text import slugify


### PR DESCRIPTION
* FIX Adds missing `invenio_base` dependency and amends past
  upgrade recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>