### PR TITLE
global: refactoring for cache

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -38,12 +38,12 @@ from __future__ import absolute_import, print_function
 import os
 
 from flask import Flask
-from flask_babelex import Babel
-from flask_menu import Menu as FlaskMenu
 from flask.ext import breadcrumbs
+from flask_babelex import Babel
 from flask_cli import FlaskCLI
-
+from flask_menu import Menu as FlaskMenu
 from invenio_db import InvenioDB
+
 from invenio_collections import InvenioCollections
 
 # Create Flask application

--- a/invenio_collections/__init__.py
+++ b/invenio_collections/__init__.py
@@ -27,7 +27,7 @@
 from __future__ import absolute_import, print_function
 
 from .ext import InvenioCollections
-from .receivers import get_record_collections
+from .proxies import current_collections
 from .version import __version__
 
-__all__ = ('__version__', 'InvenioCollections', 'get_record_collections')
+__all__ = ('__version__', 'InvenioCollections', 'current_collections')

--- a/invenio_collections/config.py
+++ b/invenio_collections/config.py
@@ -23,11 +23,20 @@ from __future__ import unicode_literals
 
 import pkg_resources
 
+COLLECTIONS_DELETED_RECORDS = '{dbquery} AND NOT collection:"DELETED"'
+"""Enhance collection query to exclude deleted records."""
+
 COLLECTIONS_QUERY_PARSER = 'invenio_query_parser.parser:Main'
 
 COLLECTIONS_QUERY_WALKERS = [
     'invenio_query_parser.walkers.pypeg_to_ast:PypegConverter',
 ]
+
+COLLECTIONS_CACHE_KEY = 'DynamicCollections::'
+"""Key prefix added before all keys in cache server."""
+
+COLLECTIONS_REGISTER_RECORD_SIGNALS = True
+"""Catch record insert/update signals and update the `_collections` field."""
 
 try:
     pkg_resources.get_distribution('invenio_search')

--- a/invenio_collections/proxies.py
+++ b/invenio_collections/proxies.py
@@ -22,37 +22,14 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
+"""Helper proxy to the state object."""
 
-root = true
+from __future__ import absolute_import, print_function
 
-[*]
-indent_style = space
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-charset = utf-8
+from flask import current_app
+from werkzeug.local import LocalProxy
 
-# Python files
-[*.py]
-indent_size = 4
-# isort plugin configuration
-known_first_party = invenio_collections
-known_third_party = invenio_db, invenio_query_parser, invenio_records
-multi_line_output = 2
-default_section = THIRDPARTY
-
-# RST files (used by sphinx)
-[*.rst]
-indent_size = 4
-
-# CSS, HTML, JS, JSON, YML
-[*.{css,html,js,json,yml}]
-indent_size = 2
-
-# Matches the exact files either package.json or .travis.yml
-[{package.json,.travis.yml}]
-indent_size = 2
-
-# Dockerfile
-[Dockerfile]
-indent_size = 4
+current_collections = LocalProxy(
+    lambda: current_app.extensions['invenio-collections']
+)
+"""Helper proxy to access state object."""

--- a/invenio_collections/query.py
+++ b/invenio_collections/query.py
@@ -20,8 +20,6 @@
 """Query parser."""
 
 import pypeg2
-
-from invenio_query_parser.walkers.pypeg_to_ast import PypegConverter
 from invenio_query_parser.walkers.match_unit import MatchUnit
 
 from .utils import parser, query_walkers

--- a/invenio_collections/utils.py
+++ b/invenio_collections/utils.py
@@ -27,7 +27,6 @@
 from __future__ import absolute_import, print_function
 
 import six
-
 from flask import current_app
 from werkzeug.utils import import_string
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -24,6 +24,7 @@
 
 
 pep257 invenio_collections && \
+isort -rc -c -df **/*.py && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
 python setup.py test && \

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,10 @@ tests_require = [
 ]
 
 extras_require = {
-    ':python_version=="2.7"': ['dojson>=0.4.0'],
+    ':python_version=="2.7"': [
+        'dojson>=0.4.0',
+        'functools32>=3.2.3',
+    ],
     'docs': [
         "Sphinx>=1.3",
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,15 +27,15 @@
 
 from __future__ import absolute_import, print_function
 
-import pytest
 import os
 
+import pytest
 from flask import Flask
-from flask_menu import Menu as FlaskMenu
 from flask.ext import breadcrumbs
 from flask_cli import FlaskCLI
-
+from flask_menu import Menu as FlaskMenu
 from invenio_db import InvenioDB, db
+
 from invenio_collections.views import blueprint
 
 

--- a/tests/test_receivers.py
+++ b/tests/test_receivers.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# -*- coding: utf-8 -*-
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Model test cases."""
+
+from __future__ import unicode_literals
+
+import os
+
+from flask import Flask
+from flask_cli import FlaskCLI
+from invenio_db import InvenioDB, db
+from invenio_records import InvenioRecords
+from invenio_records.api import Record
+from werkzeug.contrib.cache import SimpleCache
+
+from invenio_collections import InvenioCollections
+from invenio_collections.models import Collection
+
+
+def test_build_cache_with_no_collections(request):
+    """Test database backend."""
+    app = Flask(__name__)
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI=os.getenv(
+            'SQLALCHEMY_DATABASE_URI', 'sqlite://'),
+        TESTING=True,
+        SECRET_KEY='TEST',
+    )
+    FlaskCLI(app)
+    InvenioDB(app)
+    InvenioRecords(app)
+
+    cache = SimpleCache()
+    InvenioCollections(app, cache=cache)
+
+    with app.app_context():
+        db.create_all()
+
+    def teardown():
+        with app.app_context():
+            db.drop_all()
+
+    request.addfinalizer(teardown)
+
+    with app.test_request_context():
+        schema = {
+            'type': 'object',
+            'properties': {
+                'title': {'type': 'string'},
+                'field': {'type': 'boolean'},
+                'hello': {'type': 'array'},
+            },
+            'required': ['title'],
+        }
+
+        # A is creating `record0`
+        record0 = Record.create({'title': 'Test0', '$schema': schema})
+        assert record0['_collections'] == []
+
+        # somewhere, B add new collection `mycoll`
+        mycoll = Collection(name="mycoll", dbquery="title:Test0")
+        db.session.add(mycoll)
+        db.session.commit()
+
+        # reload list of collections
+        record0.commit()
+
+        # now the collection 'mycoll' should appear in `record0` of A!
+        assert record0['_collections'] == ['mycoll']

--- a/tests/test_record_signals.py
+++ b/tests/test_record_signals.py
@@ -31,9 +31,9 @@ import os
 from flask import Flask
 from flask_cli import FlaskCLI
 from invenio_db import InvenioDB, db
-
 from invenio_records import InvenioRecords
 from invenio_records.api import Record
+
 from invenio_collections import InvenioCollections
 from invenio_collections.models import Collection
 


### PR DESCRIPTION
* Adds a state objects with ability to cache results. (addresses #32)

* Adds a proxy object to easily access to last current state object.

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>