### PR TITLE
dojson: rule for converting collections to 980

### DIFF
--- a/invenio_collections/cli.py
+++ b/invenio_collections/cli.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -43,7 +43,6 @@ def dry_run(func):
     """Dry run: simulate sql execution."""
     @wraps(func)
     def inner(dry_run, *args, **kwargs):
-        db.session.begin_nested()
         ret = func(dry_run=dry_run, *args, **kwargs)
         if not dry_run:
             db.session.commit()

--- a/invenio_collections/contrib/dojson.py
+++ b/invenio_collections/contrib/dojson.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 
 from dojson import utils
 from dojson.contrib.marc21 import marc21
+from dojson.contrib.to_marc21 import to_marc21
 
 
 @marc21.over('collections', '^980..')
@@ -34,4 +35,16 @@ def collections(record, key, value):
         'primary': value.get('a'),
         'secondary': value.get('b'),
         'deleted': value.get('c'),
+    }
+
+
+@to_marc21.over('980', '^collections$')
+@utils.reverse_for_each_value
+@utils.filter_values
+def reverse_collections(self, key, value):
+    """Reverse colections field to custom MARC tag 980."""
+    return {
+        'a': value.get('primary'),
+        'b': value.get('secondary'),
+        'c': value.get('deleted'),
     }

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -75,7 +75,7 @@ install_requires = [
     'Flask>=0.10.1',
     'asciitree>=0.3.1',
     'invenio-access>=1.0.0a2',
-    'invenio-db>=1.0.0a6',
+    'invenio-db>=1.0.0a9',
     'invenio-query-parser>=0.4.1',
     'invenio-records>=1.0.0a5',
     'pyPEG2>=2.15.1',
@@ -141,6 +141,9 @@ setup(
     entry_points={
         'dojson.contrib.marc21': [
             'collections = invenio_collections.contrib.dojson',
+        ],
+        'dojson.contrib.to_marc21': [
+            '980 = invenio_collections.contrib.dojson',
         ],
         'invenio_base.apps': [
             'invenio_collections = invenio_collections:InvenioCollections',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -350,9 +350,12 @@ def test_delete(app):
             for coll in ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']:
                 assert Collection.query.filter_by(
                     name=coll).first() is not None
+            db.session.expunge_all()
 
             result = runner.invoke(cmd, ['delete', 'j'], obj=script_info)
             assert 0 == result.exit_code
+
+            db.session.expunge_all()
             for coll in ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']:
                 assert Collection.query.filter_by(
                     name=coll).first() is not None

--- a/tests/test_contrib_dojson.py
+++ b/tests/test_contrib_dojson.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -32,15 +32,15 @@ except pkg_resources.DistributionNotFound:
     pass
 else:
     from dojson.contrib.marc21 import marc21
+    from dojson.contrib.to_marc21 import to_marc21
 
     def test_invenio_collection_marc21_tag():
         """Test invenio-collection marc21 tag."""
-        data = marc21.do({'980__': {'a': 'colla', 'b': 'collb'}})
+        source = {'980__': [{'a': 'colla'}, {'b': 'collb'}]}
+        data = marc21.do(source)
 
         assert data['collections'][0]['primary'] == 'colla'
-        assert data['collections'][0]['secondary'] == 'collb'
+        assert data['collections'][1]['secondary'] == 'collb'
 
-        data = marc21.do({'980__': [{'a': 'colla'}, {'a': 'collaa'}]})
-
-        assert data['collections'][0]['primary'] == 'colla'
-        assert data['collections'][1]['primary'] == 'collaa'
+        original = to_marc21.do(data)
+        assert source['980__'] == original['980__']


### PR DESCRIPTION
* NEW Adds rule for converting JSON field collections to MARC21 field 980.  (closes #38)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>