### PR TITLE
global: fix build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,9 @@ all_files = 1
 [bdist_wheel]
 universal = 1
 
+[pydocstyle]
+add_ignore = D401
+
 [compile_catalog]
 directory = invenio_collections/translations/
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ tests_require = [
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
-    'pytest>=2.8.0',
+    'pytest>=2.8.1',
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ extras_require = {
         'functools32>=3.2.3.post2',
     ],
     'docs': [
-        'Sphinx>=1.4.2',
+        'Sphinx>=1.5.1',
     ],
     'mysql': [
         'invenio-db[mysql]>=1.0.0b3',

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ tests_require = [
 
 extras_require = {
     ':python_version=="2.7"': [
-        'functools32>=3.2.3',
+        'functools32>=3.2.3.post2',
     ],
     'docs': [
         'Sphinx>=1.4.2',


### PR DESCRIPTION
Ignores pydocstyle error code D401 ("First line should be in
imperative mood") as the parsing and detection is pretty broken.
(addresses inveniosoftware/troubleshooting#9)

Specifies more precisely the version of `functools32` that we
require as `requirements-builder` cannot deal with irregular
version numbers.

Bumps Sphinx and pytest so that the build passes.