### PR TITLE
ext: unregister before register

### DIFF
--- a/invenio_collections/ext.py
+++ b/invenio_collections/ext.py
@@ -72,6 +72,8 @@ class _AppState(object):
         from .models import Collection
         from .receivers import CollectionUpdater
 
+        self.unregister_signals()
+
         if self.app.config['COLLECTIONS_USE_PERCOLATOR']:
             from .percolator import collection_inserted_percolator, \
                 collection_removed_percolator, \


### PR DESCRIPTION
Previously successive calls to `register_signals()` had the effect
of replacing the instance of `update_function` attached to the app
state, which meant that `unregister_signals()` could only remove the
last one, but not the previous. Now, because the existing signals
are unregistered before registering again, this can't happen.

Also see: https://github.com/inspirehep/inspire-next/issues/2770#issuecomment-330934889