### PR TITLE
i18n: update string format to use %()s instead

### DIFF
--- a/.github/workflows/i18n-push.yml
+++ b/.github/workflows/i18n-push.yml
@@ -13,5 +13,6 @@ jobs:
     uses: inveniosoftware/invenio-i18n/.github/workflows/i18n-push-base.yml@master
     with:
       extract-backend: true
-      frontend-package-path: invenio_communities/assets/semantic-ui/translations/invenio_communities
+      backend-package-path: invenio_collections
+      frontend-package-path: invenio_collections/assets/semantic-ui/translations/invenio_collections
     secrets: inherit

--- a/.tx/config
+++ b/.tx/config
@@ -26,9 +26,9 @@
 # TODO: Transifex integration
 #
 # 1) Create message catalog:
-#    $ python setup.py extract_messages
-#    $ python setup.py init_catalog -l <lang>
-#    $ python setup.py compile_catalog
+#    $ pybabel extract -F pyproject.toml -o invenio_collections/translations/messages.pot invenio_collections
+#    $ pybabel init -i invenio_collections/translations/messages.pot -d invenio_collections/translations -l <lang>
+#    $ pybabel compile -d invenio_collections/translations --use-fuzzy
 # 2) Ensure project has been created on Transifex under the inveniosoftware
 #    organisation.
 # 3) Install the transifex-client

--- a/invenio_collections/errors.py
+++ b/invenio_collections/errors.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2024 CERN.
+# Copyright (C) 2026 KTH Royal Institute of Technology.
 #
 # Invenio-Collections is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -50,8 +51,10 @@ class MaxDepthExceeded(CollectionError):
         self.max_depth = max_depth
         super().__init__(
             _(
-                f"Cannot create collection at depth {current_depth + 1}. "
-                f"Maximum depth is {max_depth} (allowing depths 0-{max_depth})."
+                "Cannot create collection at depth %(current_depth)s. "
+                "Maximum depth is %(max_depth)s (allowing depths 0-%(max_depth)s).",
+                current_depth=current_depth + 1,
+                max_depth=max_depth,
             )
         )
 
@@ -65,8 +68,10 @@ class MaxTreesExceeded(CollectionError):
         self.max_trees = max_trees
         super().__init__(
             _(
-                f"Cannot create category. Namespace already has {current_count} categories. "
-                f"Maximum allowed is {max_trees}."
+                "Cannot create category. Namespace already has %(current_count)s categories. "
+                "Maximum allowed is %(max_trees)s.",
+                current_count=current_count,
+                max_trees=max_trees,
             )
         )
 
@@ -80,7 +85,9 @@ class MaxCollectionsExceeded(CollectionError):
         self.max_collections = max_collections
         super().__init__(
             _(
-                f"Cannot create collection. Category already has {current_count} collections. "
-                f"Maximum allowed is {max_collections}."
+                "Cannot create collection. Category already has %(current_count)s collections. "
+                "Maximum allowed is %(max_collections)s.",
+                current_count=current_count,
+                max_collections=max_collections,
             )
         )

--- a/invenio_collections/errors.py
+++ b/invenio_collections/errors.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 CERN.
+# SPDX-FileCopyrightText: 2026 KTH Royal Institute of Technology.
 # SPDX-License-Identifier: MIT
 """Errors for collections module."""
 
@@ -46,8 +47,10 @@ class MaxDepthExceeded(CollectionError):
         self.max_depth = max_depth
         super().__init__(
             _(
-                f"Cannot create collection at depth {current_depth + 1}. "
-                f"Maximum depth is {max_depth} (allowing depths 0-{max_depth})."
+                "Cannot create collection at depth %(current_depth)s. "
+                "Maximum depth is %(max_depth)s (allowing depths 0-%(max_depth)s).",
+                current_depth=current_depth + 1,
+                max_depth=max_depth,
             )
         )
 
@@ -61,8 +64,10 @@ class MaxTreesExceeded(CollectionError):
         self.max_trees = max_trees
         super().__init__(
             _(
-                f"Cannot create category. Namespace already has {current_count} categories. "
-                f"Maximum allowed is {max_trees}."
+                "Cannot create category. Namespace already has %(current_count)s categories. "
+                "Maximum allowed is %(max_trees)s.",
+                current_count=current_count,
+                max_trees=max_trees,
             )
         )
 
@@ -76,7 +81,9 @@ class MaxCollectionsExceeded(CollectionError):
         self.max_collections = max_collections
         super().__init__(
             _(
-                f"Cannot create collection. Category already has {current_count} collections. "
-                f"Maximum allowed is {max_collections}."
+                "Cannot create collection. Category already has %(current_count)s collections. "
+                "Maximum allowed is %(max_collections)s.",
+                current_count=current_count,
+                max_collections=max_collections,
             )
         )

--- a/invenio_collections/models.py
+++ b/invenio_collections/models.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2024 CERN.
 # Copyright (C) 2025 Graz University of Technology.
+# Copyright (C) 2026 KTH Royal Institute of Technology.
 #
 # Invenio-Collections is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -58,7 +59,8 @@ class CollectionTree(db.Model, db.Timestamp):
             if "uq_collections_collection_tree_slug_namespace_id" in str(e.orig):
                 raise DuplicateSlugError(
                     _(
-                        f"A collection tree with slug '{slug}' already exists in this namespace."
+                        "A collection tree with slug '%(slug)s' already exists in this namespace.",
+                        slug=slug,
                     )
                 )
             # Re-raise if it's a different integrity error
@@ -101,7 +103,8 @@ class CollectionTree(db.Model, db.Timestamp):
             if "uq_collections_collection_tree_slug_namespace_id" in str(e.orig):
                 raise DuplicateSlugError(
                     _(
-                        f"A collection tree with slug '{kwargs.get('slug', 'unknown')}' already exists in this namespace."
+                        "A collection tree with slug '%(slug)s' already exists in this namespace.",
+                        slug=kwargs.get("slug", "unknown"),
                     )
                 )
             # Re-raise if it's a different integrity error
@@ -179,7 +182,10 @@ class Collection(db.Model, db.Timestamp):
             # Check if it's a duplicate slug error
             if "uq_collections_collection_slug_tree_id" in str(e.orig):
                 raise DuplicateSlugError(
-                    _(f"A collection with slug '{slug}' already exists in this tree.")
+                    _(
+                        "A collection with slug '%(slug)s' already exists in this tree.",
+                        slug=slug,
+                    )
                 )
             # Re-raise if it's a different integrity error
             raise e
@@ -223,7 +229,8 @@ class Collection(db.Model, db.Timestamp):
             if "uq_collections_collection_slug_tree_id" in str(e.orig):
                 raise DuplicateSlugError(
                     _(
-                        f"A collection with slug '{kwargs.get('slug', 'unknown')}' already exists in this tree."
+                        "A collection with slug '%(slug)s' already exists in this tree.",
+                        slug=kwargs.get("slug", "unknown"),
                     )
                 )
             # Re-raise if it's a different integrity error

--- a/invenio_collections/models.py
+++ b/invenio_collections/models.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2024 CERN.
 # SPDX-FileCopyrightText: 2025 Graz University of Technology.
+# SPDX-FileCopyrightText: 2026 KTH Royal Institute of Technology.
 # SPDX-License-Identifier: MIT
 """Collections models."""
 
@@ -54,7 +55,8 @@ class CollectionTree(db.Model, db.Timestamp):
             if "uq_collections_collection_tree_slug_namespace_id" in str(e.orig):
                 raise DuplicateSlugError(
                     _(
-                        f"A collection tree with slug '{slug}' already exists in this namespace."
+                        "A collection tree with slug '%(slug)s' already exists in this namespace.",
+                        slug=slug,
                     )
                 )
             # Re-raise if it's a different integrity error
@@ -97,7 +99,8 @@ class CollectionTree(db.Model, db.Timestamp):
             if "uq_collections_collection_tree_slug_namespace_id" in str(e.orig):
                 raise DuplicateSlugError(
                     _(
-                        f"A collection tree with slug '{kwargs.get('slug', 'unknown')}' already exists in this namespace."
+                        "A collection tree with slug '%(slug)s' already exists in this namespace.",
+                        slug=kwargs.get("slug", "unknown"),
                     )
                 )
             # Re-raise if it's a different integrity error
@@ -175,7 +178,10 @@ class Collection(db.Model, db.Timestamp):
             # Check if it's a duplicate slug error
             if "uq_collections_collection_slug_tree_id" in str(e.orig):
                 raise DuplicateSlugError(
-                    _(f"A collection with slug '{slug}' already exists in this tree.")
+                    _(
+                        "A collection with slug '%(slug)s' already exists in this tree.",
+                        slug=slug,
+                    )
                 )
             # Re-raise if it's a different integrity error
             raise e
@@ -219,7 +225,8 @@ class Collection(db.Model, db.Timestamp):
             if "uq_collections_collection_slug_tree_id" in str(e.orig):
                 raise DuplicateSlugError(
                     _(
-                        f"A collection with slug '{kwargs.get('slug', 'unknown')}' already exists in this tree."
+                        "A collection with slug '%(slug)s' already exists in this tree.",
+                        slug=kwargs.get("slug", "unknown"),
                     )
                 )
             # Re-raise if it's a different integrity error

--- a/invenio_collections/services/schema.py
+++ b/invenio_collections/services/schema.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2024 CERN.
+# Copyright (C) 2026 KTH Royal Institute of Technology.
 #
 # Invenio-Collections is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 """Collections schema."""
 
+from flask_babel import gettext
 from flask_babel import lazy_gettext as _
 from luqum.exceptions import ParseError
 from luqum.parser import parser as luqum_parser
@@ -19,7 +21,7 @@ def validate_search_query(query):
         luqum_parser.parse(query)
     except ParseError as e:
         raise ValidationError(
-            _("Invalid search query: {error}").format(error=str(e))
+            gettext("Invalid search query: %(error)s", error=str(e))
         ) from e
 
 

--- a/invenio_collections/services/schema.py
+++ b/invenio_collections/services/schema.py
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: 2024 CERN.
+# SPDX-FileCopyrightText: 2026 KTH Royal Institute of Technology.
 # SPDX-License-Identifier: MIT
 """Collections schema."""
 
+from flask_babel import gettext
 from flask_babel import lazy_gettext as _
 from luqum.exceptions import ParseError
 from luqum.parser import parser as luqum_parser
@@ -15,7 +17,7 @@ def validate_search_query(query):
         luqum_parser.parse(query)
     except ParseError as e:
         raise ValidationError(
-            _("Invalid search query: {error}").format(error=str(e))
+            gettext("Invalid search query: %(error)s", error=str(e))
         ) from e
 
 

--- a/invenio_collections/translations/messages.pot
+++ b/invenio_collections/translations/messages.pot
@@ -1,0 +1,89 @@
+# Translations template for PROJECT.
+# Copyright (C) 2026 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-06-23 13:25+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: invenio_collections/errors.py:50
+#, python-format
+msgid ""
+"Cannot create collection at depth %(current_depth)s. Maximum depth is "
+"%(max_depth)s (allowing depths 0-%(max_depth)s)."
+msgstr ""
+
+#: invenio_collections/errors.py:67
+#, python-format
+msgid ""
+"Cannot create category. Namespace already has %(current_count)s "
+"categories. Maximum allowed is %(max_trees)s."
+msgstr ""
+
+#: invenio_collections/errors.py:84
+#, python-format
+msgid ""
+"Cannot create collection. Category already has %(current_count)s "
+"collections. Maximum allowed is %(max_collections)s."
+msgstr ""
+
+#: invenio_collections/models.py:58 invenio_collections/models.py:102
+#, python-format
+msgid "A collection tree with slug '%(slug)s' already exists in this namespace."
+msgstr ""
+
+#: invenio_collections/models.py:182 invenio_collections/models.py:228
+#, python-format
+msgid "A collection with slug '%(slug)s' already exists in this tree."
+msgstr ""
+
+#: invenio_collections/resources/config.py:65
+msgid "Collection was not found."
+msgstr ""
+
+#: invenio_collections/resources/config.py:68
+msgid "Collection tree was not found."
+msgstr ""
+
+#: invenio_collections/resources/config.py:74
+msgid "Cannot delete collection tree until all collections have been deleted."
+msgstr ""
+
+#: invenio_collections/resources/config.py:82
+msgid "Cannot delete collection until all children have been deleted."
+msgstr ""
+
+#: invenio_collections/resources/config.py:90
+msgid "A collection with this slug already exists in this context."
+msgstr ""
+
+#: invenio_collections/services/schema.py:20
+#, python-format
+msgid "Invalid search query: %(error)s"
+msgstr ""
+
+#: invenio_collections/services/schema.py:35
+msgid "Slug: letters, numbers, underscores, or hyphens only."
+msgstr ""
+
+#: invenio_collections/services/schema.py:48
+#: invenio_collections/services/schema.py:61
+#: invenio_collections/services/schema.py:77
+msgid "Order must be non-negative."
+msgstr ""
+
+#: invenio_collections/services/schema.py:87
+msgid "At least one item required."
+msgstr ""
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ invenio_collections = "invenio_collections:alembic"
 [project.entry-points."invenio_db.models"]
 invenio_collections = "invenio_collections.models"
 
+[project.entry-points."invenio_i18n.translations"]
+messages = "invenio_collections"
+
 # Tools in alphabetical order
 [tool.babel.compile_catalog]
 directory = "invenio_collections/translations/"
@@ -72,7 +75,7 @@ use_fuzzy = true
 [tool.babel.extract_messages]
 copyright_holder = "CERN"
 msgid_bugs_address = "info@inveniosoftware.org"
-mapping_file = "babel.ini"
+mapping_file = "pyproject.toml"
 output_file = "invenio_collections/translations/messages.pot"
 add_comments = "NOTE"
 
@@ -80,18 +83,23 @@ add_comments = "NOTE"
 input_file = "invenio_collections/translations/messages.pot"
 output_dir = "invenio_collections/translations/"
 
-[tool.babel.javascript]
-"**.js" = { encoding = "utf-8", extract_messages = ["$_", "jQuery._"] }
+# see https://babel.pocoo.org/en/latest/messages.html#toml-configuration-format
+[tool.babel]
+[[tool.babel.mappings]]
+method = "javascript"
+pattern = "**.js"
+encoding = "utf-8"
+extract_messages = "$._, jQuery._"
 
-[tool.babel.jinja2]
-"**/templates/**.html" = { encoding = "utf-8" }
+[[tool.babel.mappings]]
+method = "python"
+pattern = "**.py"
+encoding = "utf-8"
 
-[tool.babel.python]
-"**.py" = { encoding = "utf-8" }
-
-[tool.babel.update_catalog]
-input_file = "invenio_collections/translations/messages.pot"
-output_dir = "invenio_collections/translations/"
+[[tool.babel.mappings]]
+method = "jinja2"
+pattern = "**/templates/**.html"
+encoding = "utf-8"
 
 [tool.hatch.version]
 path = "invenio_collections/__init__.py"
@@ -115,4 +123,3 @@ testpaths = [
 filterwarnings = [
     "ignore::marshmallow.warnings.RemovedInMarshmallow4Warning",
 ]
-


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Changed format strings in error classes to use the %() syntax for better localization support.
* related to https://github.com/inveniosoftware/invenio-communities/issues/1370

> AI use disclosure: Most of this PR was generated with Codex, with additional guidance, cleanup, and adjustments to match the existing codebase style.


* related: https://github.com/inveniosoftware/invenio-app-rdm/issues/3499

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
