### PR TITLE
fix(build): include mo files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,11 @@ encoding = "utf-8"
 [tool.hatch.version]
 path = "invenio_collections/__init__.py"
 
+[tool.hatch.build]
+artifacts = [
+  "*.mo",
+]
+
 [tool.isort]
 profile = "black"
 


### PR DESCRIPTION
Backport the inclusion of `*.mo` files into the built wheels.